### PR TITLE
fix: remove the extra empty width for tavern page

### DIFF
--- a/sections/SectionRecruit.js
+++ b/sections/SectionRecruit.js
@@ -49,9 +49,13 @@ function	Class({provider, rarityClass, fetchRarity, router}) {
 }
 
 function	SectionRecruit({shouldDisplay, router, provider, fetchRarity}) {
+    if (!shouldDisplay) {
+        return null;
+    }
+
 	return (
-		<section className={`flex flex-row w-full flex-wrap items-center justify-center ${shouldDisplay ? '' : 'opacity-0 h-0 max-h-0 min-h-0 w-0 max-w-0 min-w-0 pointer-events-none'}`}>
-			<div className={`grid-cols-1 md:grid-cols-4 gap-4 md:gap-8 ${shouldDisplay ? 'grid' : 'hidden md:flex'}`}>
+		<section className="flex flex-row w-full flex-wrap items-center justify-center">
+			<div className="grid grid-cols-1 md:grid-cols-4 gap-4 md:gap-8">
 				<Class router={router} provider={provider} fetchRarity={fetchRarity} rarityClass={classes['Barbarian']} />
 				<Class router={router} provider={provider} fetchRarity={fetchRarity} rarityClass={classes['Bard']} />
 				<Class router={router} provider={provider} fetchRarity={fetchRarity} rarityClass={classes['Cleric']} />


### PR DESCRIPTION
The tarven page shows a horizontal scrollbar when the browser window is narrower than 1950px. This scrollbar is unnecessary because there's no content for the extra width. 

![Snip20210912_3](https://user-images.githubusercontent.com/5376112/133007986-8600ae5e-58eb-4235-9a7a-a28d38429974.png)

The root cause of the issue is that the SectionRecruit component has min width even when it is hidden. 

The fix is to not render SectionRecruit at all, instead of rendering then hiding it. 

 