### PR TITLE
fix: only switch chain when in focus

### DIFF
--- a/contexts/useWeb3.js
+++ b/contexts/useWeb3.js
@@ -85,7 +85,7 @@ export const Web3ContextApp = ({children}) => {
 	// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [account, chainId, connector, library, onDesactivate, onUpdate]);
 
-	function	switchChain() {
+	const switchChain = useCallback(() => {
 		if (Number(chainID) === 250) {
 			return;
 		}
@@ -104,7 +104,7 @@ export const Web3ContextApp = ({children}) => {
 				'decimals': 18
 			}
 		}, address]).catch((error) => console.error(error));
-	}
+	}, [active, address, chainID, provider]);
 
 	/**************************************************************************
 	**	connect
@@ -126,7 +126,7 @@ export const Web3ContextApp = ({children}) => {
 			}
 			await (window.ethereum.send)('eth_accounts');
 
-			const	injected = new InjectedConnector({supportedChainIds: [1, 250, 1337]});
+			const	injected = new InjectedConnector();
 			await activate(injected, (e) => console.error(e), false);
 			set_lastWallet(walletType.METAMASK);
 			set_isActivated(true);

--- a/hook/useWindowInFocus.js
+++ b/hook/useWindowInFocus.js
@@ -1,0 +1,28 @@
+/******************************************************************************
+**	@Author:				Rarity Extended
+**	@Twitter:				@MajorTom_eth
+**	@Date:					Sunday September 12th 2021
+**	@Filename:				useWindowInFocus.js
+******************************************************************************/
+
+import React from 'react';
+
+const useWindowInFocus = () => {
+	const [focused, setFocused] = React.useState(true);
+	React.useEffect(() => {
+		const onFocus = () => setFocused(true);
+		const onBlur = () => setFocused(false);
+
+		window.addEventListener('focus', onFocus);
+		window.addEventListener('blur', onBlur);
+
+		return () => {
+			window.removeEventListener('focus', onFocus);
+			window.removeEventListener('blur', onBlur);
+		};
+	}, []);
+
+	return focused;
+};
+
+export default useWindowInFocus;

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -18,6 +18,7 @@ import	{UIContextApp}					from	'contexts/useUI';
 import	Navbar							from	'components/Navbar';
 import	Footer							from	'components/Footer';
 import	SectionNoWallet					from	'sections/SectionNoWallet';
+import	useWindowInFocus				from	'hook/useWindowInFocus';
 
 import	'tailwindcss/tailwind.css';
 import	'style/Default.css';
@@ -63,12 +64,13 @@ function	GameWrapper({Component, pageProps, element, router}) {
 function	AppWrapper(props) {
 	const	{Component, pageProps, router} = props;
 	const	{switchChain, chainID} = useWeb3();
+	const	windowInFocus = useWindowInFocus();
 
 	React.useEffect(() => {
-		if (Number(chainID) > 0 && (Number(chainID) !== 250 && Number(chainID) !== 1337)) {
+		if (windowInFocus && Number(chainID) > 0 && (Number(chainID) !== 250 && Number(chainID) !== 1337)) {
 			switchChain();
 		}
-	}, [chainID]);
+	}, [chainID, windowInFocus, switchChain]);
 
 	return (
 		<>
@@ -130,7 +132,7 @@ const getLibrary = (provider) => {
 
 function	MyApp(props) {
 	const	{Component, pageProps} = props;
-	
+
 	return (
 		<UIContextApp>
 			<Web3ReactProvider getLibrary={getLibrary}>


### PR DESCRIPTION
With the current auto chain switch logic, it is disruptive when users have multiple dapps open across different chains. Add a hook to check whether window is in focus and only prompt to chain network when it is in focus.

Also, fix a bug where `supportedChainIds` was set to a narrow set. This made the page swallow error when connecting wallet from an unknown network. Now that we have chain switch code, we can accept any network and prompt user to switch after wallet is injected.
To reproduce this error, start the dapp with an unsupported network, e.g. polygon, and users do not get prompt to change network.
