### PR TITLE
Fix/Rat fight revert

### DIFF
--- a/contexts/useRarity.js
+++ b/contexts/useRarity.js
@@ -65,7 +65,6 @@ export const RarityContextApp = ({children}) => {
 			rarityAttr.character_created(tokenID),
 			rarityAttr.ability_scores(tokenID),
 			rarityGold.balanceOf(tokenID),
-			rarityDungeonCellar.balanceOf(tokenID),
 			rarityDungeonCellar.adventurers_log(tokenID),
 		];
 	}
@@ -184,7 +183,7 @@ export const RarityContextApp = ({children}) => {
 		// preparedCalls.push(...prepareAdventurer(258181)); preparedExtraCalls.push(...prepareAdventurerExtra(258181)); tokensIDs.push(258181);
 
 		const	callResults = await fetchAdventurer(preparedCalls);
-		const	chunkedCallResult = chunk(callResults, 7);
+		const	chunkedCallResult = chunk(callResults, 6);
 		const	extraCallResults = await fetchAdventurerExtra(preparedExtraCalls);
 		const	chunkedExtraCallResult = chunk(extraCallResults, 1);
 		const	inventoryCallResult = await fetchAdventurerInventory(preparedInventoryCalls);
@@ -201,7 +200,7 @@ export const RarityContextApp = ({children}) => {
 	**************************************************************************/
 	async function	updateRarity(tokenID) {
 		const	callResults = await fetchAdventurer(prepareAdventurer(tokenID));
-		const	chunkedCallResult = chunk(callResults, 7);
+		const	chunkedCallResult = chunk(callResults, 6);
 		const	extraCallResults = await fetchAdventurerExtra(prepareAdventurerExtra(tokenID));
 		const	chunkedExtraCallResult = chunk(extraCallResults, 1);
 		const	inventoryCallResult = await fetchAdventurerInventory(prepareAdventurerInventory(tokenID));

--- a/contexts/useWeb3.js
+++ b/contexts/useWeb3.js
@@ -127,7 +127,7 @@ export const Web3ContextApp = ({children}) => {
 			await (window.ethereum.send)('eth_accounts');
 
 			const	injected = new InjectedConnector();
-			await activate(injected, (e) => console.error(e), false);
+			await activate(injected, undefined, true);
 			set_lastWallet(walletType.METAMASK);
 			set_isActivated(true);
 		} else if (_providerType === walletType.WALLET_CONNECT) {

--- a/utils/actions.js
+++ b/utils/actions.js
@@ -60,6 +60,7 @@ export async function	goAdventure({provider, contractAddress, tokenID}, callback
 export async function	lootDungeonTheCellar({provider, contractAddress, tokenID}, callback) {
 	_adventure('Looting the Big Ugly Rat...', {provider, contractAddress, tokenID}, callback);
 }
+
 export async function	levelUp({provider, contractAddress, tokenID}, callback) {
 	const	_toast = toast.loading(`Level-up ${tokenID}...`);
 	const	signer = provider.getSigner();

--- a/yarn.lock
+++ b/yarn.lock
@@ -9612,9 +9612,9 @@ swarm-js@^0.1.40:
     xhr-request "^1.0.1"
 
 swr@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/swr/-/swr-1.0.0.tgz#d047933714d8bd16ae35af67d81149f4ae700a4d"
-  integrity sha512-v55Dr+vxIFiUyGxC5W4uN5falxHxYdbpb/R3bO+bSG+svbC9bUWmupy4NM/2pER7X8OvgwJWu0AiSoGy0ND9ew==
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-1.0.1.tgz#15f62846b87ee000e52fa07812bb65eb62d79483"
+  integrity sha512-EPQAxSjoD4IaM49rpRHK0q+/NzcwoT8c0/Ylu/u3/6mFj/CWnQVjNJ0MV2Iuw/U+EJSd2TX5czdAwKPYZIG0YA==
   dependencies:
     dequal "2.0.2"
 


### PR DESCRIPTION
## What it does ✨
Fix an issue where you could not fight the rat (execution reverted). This was because of an extra param in the multicall following the inventory implementation. The log (aka when the user will be available to fight again) was not correctly fetched and so the adventurer was always ready to fight, even if this was not the true


## How to test ✅
Try to fight with your adventurer, they should no be able to fight again and the tx should not revert